### PR TITLE
엔티티 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
+**/src/main/resources/application.yaml
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,15 @@ dependencies {
     // lombok
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+    // spring data jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/catchplace/catchplacebackend/constant/SnsType.java
+++ b/src/main/java/org/catchplace/catchplacebackend/constant/SnsType.java
@@ -1,0 +1,5 @@
+package org.catchplace.catchplacebackend.constant;
+
+public enum SnsType {
+    Kakao
+}

--- a/src/main/java/org/catchplace/catchplacebackend/constant/UserRole.java
+++ b/src/main/java/org/catchplace/catchplacebackend/constant/UserRole.java
@@ -1,0 +1,18 @@
+package org.catchplace.catchplacebackend.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    SERVICE_ADMIN("ROLE_SERVICE_ADMIN", "서비스 관리자"),
+    VISITOR("ROLE_VISITOR", "방문자");
+
+    private final String key;
+    private final String description;
+
+    UserRole(String key, String description) {
+        this.key = key;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/org/catchplace/catchplacebackend/constant/WaitingStatus.java
+++ b/src/main/java/org/catchplace/catchplacebackend/constant/WaitingStatus.java
@@ -1,0 +1,18 @@
+package org.catchplace.catchplacebackend.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum WaitingStatus {
+    WAITING("대기중"),
+    ENTERED("입장"),
+    CANCELLED_BY_USER("본인에 의해 대기 취소"),
+    CANCELLED_BY_OPERATOR("부스 운영자에 의해 대기 취소");
+
+    private final String description;
+
+    WaitingStatus(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
@@ -57,10 +57,10 @@ public class Booth {
     private LocalDateTime endDate;
 
     @Column(nullable = false)
-    private LocalDateTime openTime;
+    private java.time.LocalTime openTime;
 
     @Column(nullable = false)
-    private LocalDateTime endTime;
+    private java.time.LocalTime endTime;
 
 
     @CreationTimestamp

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
@@ -1,0 +1,73 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "booth")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Booth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, length = 200)
+    private String location;
+
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<BoothCategory> boothCategories = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User operator;
+
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Photo> photos = new ArrayList<>();
+
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Waiting> waitings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<BoothOption> boothOptions = new ArrayList<>();
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime startDate;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime endDate;
+
+    @Column(nullable = false)
+    private LocalDateTime openTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Booth.java
@@ -30,7 +30,7 @@ public class Booth {
     @Column(nullable = false, length = 200)
     private String location;
 
-    @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "booth", orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
     private List<BoothCategory> boothCategories = new ArrayList<>();
 

--- a/src/main/java/org/catchplace/catchplacebackend/entity/BoothCategory.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/BoothCategory.java
@@ -1,0 +1,25 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "booth_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class BoothCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id", nullable = false)
+    private Booth booth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/BoothOption.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/BoothOption.java
@@ -1,0 +1,50 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "booth_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class BoothOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id", nullable = false)
+    private Booth booth;
+
+    @Column(nullable = false, length = 100)
+    private String name; // 옵션 이름 (예: "전공학과를 선택해주세요")
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isRequired = false; // 필수 선택 여부
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer displayOrder = 0; // 표시 순서
+
+    @OneToMany(mappedBy = "boothOption", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<BoothOptionItem> items = new ArrayList<>(); // 옵션 항목들
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/BoothOptionItem.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/BoothOptionItem.java
@@ -1,0 +1,40 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "booth_option_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class BoothOptionItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_option_id", nullable = false)
+    private BoothOption boothOption;
+
+    @Column(nullable = false, length = 100)
+    private String name; // 항목 이름 (예: "컴퓨터공학과", "전자정보통신공학과")
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer displayOrder = 0; // 표시 순서
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Category.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Category.java
@@ -1,0 +1,27 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<BoothCategory> boothCategories = new ArrayList<>();
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Photo.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Photo.java
@@ -1,0 +1,35 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "photo")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Photo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id", nullable = false)
+    private Booth booth;
+
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer displayOrder = 0; // 사진 표시 순서
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/User.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/User.java
@@ -46,7 +46,7 @@ public class User implements OAuth2User {
     @Builder.Default
     private UserRole role = UserRole.VISITOR;
 
-    @OneToMany(mappedBy = "operator", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "operator", fetch = FetchType.LAZY)
     @Builder.Default
     private List<Booth> operatedBooths = new ArrayList<>();
 
@@ -64,16 +64,16 @@ public class User implements OAuth2User {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return null;
+        return Collections.emptyMap();
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton((GrantedAuthority) () -> role.getKey());
+        return Collections.singleton(new org.springframework.security.core.authority.SimpleGrantedAuthority(role.getKey()));
     }
 
     @Override
     public String getName() {
-        return name;
+        return snsId;
     }
 }

--- a/src/main/java/org/catchplace/catchplacebackend/entity/User.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/User.java
@@ -1,0 +1,79 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.catchplace.catchplacebackend.constant.SnsType;
+import org.catchplace.catchplacebackend.constant.UserRole;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class User implements OAuth2User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String snsId;
+
+    @Column(nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private SnsType snsType;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String telephone;
+
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private UserRole role = UserRole.VISITOR;
+
+    @OneToMany(mappedBy = "operator", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Booth> operatedBooths = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Waiting> waitings = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton((GrantedAuthority) () -> role.getKey());
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Waiting.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Waiting.java
@@ -57,7 +57,7 @@ public class Waiting {
 
     @UpdateTimestamp
     @Column(nullable = false)
-    private LocalDateTime statusUpdatedAt; // 현재 상태 업데이트 시간
+    private LocalDateTime updatedAt;
 
     // 상태 변경 메서드
     public void updateStatus(WaitingStatus newStatus) {

--- a/src/main/java/org/catchplace/catchplacebackend/entity/Waiting.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/Waiting.java
@@ -1,0 +1,83 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.catchplace.catchplacebackend.constant.WaitingStatus;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "waiting")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Waiting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_id", nullable = false)
+    private Booth booth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 등록자
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer adultCount = 0;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer childCount = 0;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer infantCount = 0;
+
+    @Column(nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private WaitingStatus status = WaitingStatus.WAITING;
+
+    @OneToMany(mappedBy = "waiting", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<WaitingOption> waitingOptions = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime statusUpdatedAt; // 현재 상태 업데이트 시간
+
+    // 상태 변경 메서드
+    public void updateStatus(WaitingStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    // 총 인원 조회 메서드
+    public Integer getTotalPartySize() {
+        return adultCount + childCount + infantCount;
+    }
+
+    // 인원 유효성 검사
+    @PrePersist
+    @PreUpdate
+    private void validatePartySize() {
+        if (adultCount < 0 || childCount < 0 || infantCount < 0) {
+            throw new IllegalArgumentException("인원은 0명 이상이어야 합니다.");
+        }
+        if (getTotalPartySize() < 1) {
+            throw new IllegalArgumentException("총 인원은 1명 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/org/catchplace/catchplacebackend/entity/WaitingOption.java
+++ b/src/main/java/org/catchplace/catchplacebackend/entity/WaitingOption.java
@@ -1,0 +1,36 @@
+package org.catchplace.catchplacebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "waiting_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class WaitingOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "waiting_id", nullable = false)
+    private Waiting waiting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_option_id", nullable = false)
+    private BoothOption boothOption;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booth_option_item_id", nullable = false)
+    private BoothOptionItem boothOptionItem;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=catch-place-backend


### PR DESCRIPTION
## 📌 Related Issue
- #1 

## 🚀 Description
요구사항을 바탕으로 엔티티를 설계하고 구성하였습니다.

### 의존성
OAuth 기반의 사용자 인증으로 인해 미리 OAuth와 관련된 의존성을 추가하고 User 엔티티가 OAuth2User를 상속받도록 구현했습니다.
이외에도 JPA와 MySQL에 대한 의존성도 추가하였습니다.

### FetchType
JPA N+1 문제를 방지하기 위해 `FetchType.LAZY`를 적용하였습니다. 하지만 이것으로 완전히 해결될 수 없으므로 이후 구현과정에서 Fetch Join 혹은 Batch Size 조절을 통해 병목이 생기지 않도록 주시하겠습니다.

## 📢 Notes
이외에 알릴만한 내용이 있다면 작성해주세요